### PR TITLE
Add tests for fsevent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ version = "~0.1.0"
 [dependencies]
 bitflags = "*"
 libc = "*"
+
+[dev-dependencies]
+tempdir = "^0.3.4"
+time = "*"

--- a/tests/fsevent.rs
+++ b/tests/fsevent.rs
@@ -1,0 +1,109 @@
+extern crate fsevent;
+extern crate tempdir;
+extern crate time;
+
+use fsevent::*;
+use std::io::Write;
+use std::fs::OpenOptions;
+use std::fs::read_link;
+use std::path::{Component, Path, PathBuf};
+use std::thread;
+use std::sync::mpsc::{channel, Sender, Receiver};
+use tempdir::TempDir;
+use std::env;
+
+const TIMEOUT_S: f64 = 5.0;
+
+fn validate_recv(rx: Receiver<Event>, evs: Vec<(String, StreamFlags)>) {
+  let mut deadline = time::precise_time_s() + TIMEOUT_S;
+  let mut evs = evs.clone();
+
+  while (time::precise_time_s() < deadline) {
+      if let Ok(actual) = rx.try_recv() {
+          println!("actual: {:?}", actual);
+          let mut found: Option<usize> = None;
+          for i in (0..evs.len()) {
+            let expected = evs.get(i).unwrap();
+            if actual.path == expected.0 && actual.flag == expected.1 {
+                found = Some(i);
+                break;
+            }
+          }
+          if let Some(i) = found {
+              evs.remove(i);
+          } else {
+            assert!(false, format!("actual: {:?} not found in expected: {:?}", actual, evs));
+          }
+      }
+      if evs.is_empty() { break; }
+  }
+  assert!(evs.is_empty(),
+          "Some expected events did not occur before the test timedout:\n\t\t{:?}", evs);
+}
+
+
+// TODO: replace with std::fs::canonicalize rust-lang/rust#27706.
+fn resolvePath(path: &str) -> PathBuf {
+    let mut out = PathBuf::new();
+    let buf = PathBuf::from(path);
+    for p in buf.components() {
+        match p {
+          Component::RootDir => out.push("/"),
+          Component::Normal(osstr) => {
+              out.push(osstr);
+              if let Ok(real) = read_link(&out) {
+                  if real.is_relative() {
+                    out.pop();
+                    out.push(real);
+                  } else {
+                    out = real;
+                  }
+              }
+          }
+          _ => ()
+        }
+    }
+    out
+}
+
+#[test]
+fn validate_watch_single_file() {
+  let dir = TempDir::new("dir").unwrap();
+  // Resolve path so we don't have to worry about affect of symlinks on the test.
+  let mut dst = resolvePath(dir.path().to_str().unwrap());
+  dst.push("out.txt");
+  let (sender, receiver) = channel();
+
+  let mut file = OpenOptions::new().write(true).create(true).open(dst.clone().as_path()).unwrap();
+  file.write_all(b"create").unwrap();
+  file.flush().unwrap();
+  drop(file);
+  println!("Just created file");
+
+  {
+    let dst = dst.clone();
+    let _t = thread::spawn(move || {
+      thread::sleep_ms(1000); // Wait a while after create above before observing.
+      println!("Will observe now");
+      let fsevent = fsevent::FsEvent::new(sender);
+      fsevent.append_path(dst.as_path().to_str().unwrap());
+      fsevent.observe();
+    });
+  }
+
+  {
+    let dst = dst.clone();
+    let t3 = thread::spawn(move || {
+      thread::sleep_ms(1500); // Wait another 500ms after observe.
+      println!("Will append to file now");
+      let mut file = OpenOptions::new().write(true).append(true).open(dst.as_path()).unwrap();
+      file.write_all(b"foo").unwrap();
+      file.flush().unwrap();
+    });
+    t3.join().unwrap();
+  }
+
+  validate_recv(receiver, vec![
+    (dst.to_str().unwrap().to_string(), ITEM_MODIFIED | IS_FILE),
+  ]);
+}


### PR DESCRIPTION
**Not ready for merge**

I adapted these from the rsnotify tests but use a timeout and don't enforce event order.
I haven't been able to get these to pass at all though.

No matter where I insert `thread::sleep` after the file creation the watched file always gets an event with flags `ITEM_CREATED | ITEM_MODIFIED | IS_FILE`

In the current state here is the test failure:

```
 > cargo test
     Running target/debug/fsevent-bcd99ee57f058d7e

running 1 test
Will observe now
Will append to file now
test validate_watch_single_file ... FAILED

failures:

---- validate_watch_single_file stdout ----
	Just created file
actual: Event { event_id: 11952012, flag: ITEM_CREATED | ITEM_MODIFIED | IS_FILE, path: "/private/var/folders/00/135tr000h01000cxqpysvccm004cqb/T/dir.s9ofVm78kMkO/out.txt" }
thread 'validate_watch_single_file' panicked at 'actual: Event { event_id: 11952012, flag: ITEM_CREATED | ITEM_MODIFIED | IS_FILE, path: "/private/var/folders/00/135tr000h01000cxqpysvccm004cqb/T/dir.s9ofVm78kMkO/out.txt" } not found in expected: [("/private/var/folders/00/135tr000h01000cxqpysvccm004cqb/T/dir.s9ofVm78kMkO/out.txt", ITEM_MODIFIED | IS_FILE)]', tests/fsevent.rs:35

stack backtrace:
   1:        0x10f0fe565 - sys::backtrace::write::hf5ea20500b66cd24uns
   2:        0x10f101e23 - panicking::on_panic::hbe02cb0d925cad49iGw
   3:        0x10f0f3c42 - rt::unwind::begin_unwind_inner::h12ba0ba9dffdecc2uow
   4:        0x10f06f935 - rt::unwind::begin_unwind::h13335596912956014251
   5:        0x10f05dec1 - validate_recv::h616d85b7c74985a8zaa
   6:        0x10f073bf4 - validate_watch_single_file::hafcd4e05aad43812nga
   7:        0x10f0c06e0 - boxed::F.FnBox<A>::call_box::h11070975173153378549
   8:        0x10f0c361f - boxed::F.FnBox<A>::call_box::h1372358435100094416
   9:        0x10f0c0ee7 - rt::unwind::try::try_fn::h5361545742513409503
  10:        0x10f103b48 - rust_try_inner
  11:        0x10f103b35 - rust_try
  12:        0x10f0fd4a5 - rt::unwind::try::inner_try::h480e3107f6a4b5b9nkw
  13:        0x10f0c1118 - boxed::F.FnBox<A>::call_box::h12826721353945353732
  14:        0x10f100a1d - sys::thread::Thread::new::thread_start::hdb3d925f69c5da4aHIv
  15:     0x7fff92440267 - _pthread_body
  16:     0x7fff924401e4 - _pthread_start


failures:
    validate_watch_single_file

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured

thread '<main>' panicked at 'Some tests failed', ../src/libtest/lib.rs:255
stack backtrace:
   1:        0x10f0fe565 - sys::backtrace::write::hf5ea20500b66cd24uns
   2:        0x10f102095 - panicking::on_panic::hbe02cb0d925cad49iGw
   3:        0x10f0f3c42 - rt::unwind::begin_unwind_inner::h12ba0ba9dffdecc2uow
   4:        0x10f09f676 - rt::unwind::begin_unwind::h17788042703409534955
   5:        0x10f0a1323 - test_main::he3317e9b11453a96I1a
   6:        0x10f0a7b41 - test_main_static::h818c3572a7d0c571d4a
   7:        0x10f07ca9c - __test::main::h4a46bda5e9d5f9fcdka
   8:        0x10f103b48 - rust_try_inner
   9:        0x10f103b35 - rust_try
  10:        0x10f1029f3 - rt::lang_start::hd8f037e4034ec509fBw
  11:        0x10f07cafe - main
```

Even though I haven't had much success making a passing test I wanted to share in case it was helpful for anyone else's debugging.
