### PR TITLE
fix cast on i686-apple-darwin

### DIFF
--- a/fsevent-sys/core_foundation.rs
+++ b/fsevent-sys/core_foundation.rs
@@ -145,7 +145,7 @@ pub fn system_version_bugfix() -> SInt32 {
 pub unsafe fn str_path_to_cfstring_ref(source: &str) -> CFStringRef {
   let c_path = CString::new(source).unwrap();
   let c_len = libc::strlen(c_path.as_ptr());
-  let mut url = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, c_path.as_ptr(), c_len as i64, false);
+  let mut url = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, c_path.as_ptr(), c_len as CFIndex, false);
   let mut placeholder = CFURLCopyAbsoluteURL(url);
   CFRelease(url);
 


### PR DESCRIPTION
CFIndex (c_long) is i32 on this target

`cargo build --target i686-apple-darwin` was failing before this patch.