### PR TITLE
Fix type in IS_LAST_HARDLINK flag

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -60,7 +60,7 @@ bitflags! {
     const IS_SYMLIMK = 0x00040000,
     const OWN_EVENT = 0x00080000,
     const IS_HARDLINK = 0x00100000,
-    const IS_LAST_HARDLINK = 0x0020000
+    const IS_LAST_HARDLINK = 0x00200000
   }
 }
 


### PR DESCRIPTION
Just a small typo I think?

From my local  `FSEvents.h`:

```
  /* Indicates the object at the specific path supplied in this event was the last hard link.
   * (This flag is only ever set if you specified the FileEvents flag when creating the stream.)
   */
  kFSEventStreamEventFlagItemIsLastHardlink __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_9_0) = 0x00200000,
```