### PR TITLE
Add async form of FsEvent::observe function.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,4 @@ insert_final_newline = true
 [*.rs]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 /target/
 
 Cargo.lock
+
+# IntelliJ Files
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fsevent"
-version = "0.3.0"
+version = "0.4.0"
 authors = [ "Pierre Baillet <pierre@baillet.name>" ]
 description = "Rust bindings to the fsevent-sys macOS API for file changes notifications"
 license="MIT"

--- a/examples/fsevent-async-demo.rs
+++ b/examples/fsevent-async-demo.rs
@@ -1,0 +1,26 @@
+extern crate fsevent;
+
+use std::sync::mpsc::channel;
+use std::thread;
+
+fn main() {
+    let (sender, receiver) = channel();
+
+    let _t = thread::spawn(move || {
+        let fsevent = fsevent::FsEvent::new(vec![".".to_string()]);
+        let handle = fsevent.observe_async(sender).unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(5)); // sleep five seconds
+        fsevent.shutdown_observe(handle);
+    });
+
+    loop {
+        let duration = std::time::Duration::from_secs(1);
+        match receiver.recv_timeout(duration) {
+            Ok(val) => println!("{:?}", val),
+            Err(e) => match e {
+                std::sync::mpsc::RecvTimeoutError::Disconnected => break,
+                _ => {} // This is the case where nothing entered the channel buffer (no file mods).
+            }
+        }
+    }
+}

--- a/examples/fsevent-demo.rs
+++ b/examples/fsevent-demo.rs
@@ -6,9 +6,8 @@ fn main() {
     let (sender, receiver) = channel();
 
     let _t = thread::spawn(move || {
-        let fsevent = fsevent::FsEvent::new(sender);
-        fsevent.append_path(".").unwrap();
-        fsevent.observe();
+        let fsevent = fsevent::FsEvent::new(vec![".".to_string()]);
+        fsevent.observe(sender);
     });
 
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ type SafePointer = u64;
 #[cfg(target_pointer_width = "32")]
 type SafePointer = u32;
 
+#[derive(Clone, Copy, Debug)]
 pub struct FsEventRefWrapper {
     ptr: SafePointer,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,37 @@ use std::str::from_utf8;
 
 use std::sync::mpsc::Sender;
 
+
+#[cfg(target_pointer_width = "64")]
+type SafePointer = u64;
+
+#[cfg(target_pointer_width = "32")]
+type SafePointer = u32;
+
+pub struct FsEventRefWrapper {
+    ptr: SafePointer,
+}
+
+impl From<*mut ::std::os::raw::c_void> for FsEventRefWrapper {
+    fn from(raw: *mut ::std::os::raw::c_void) -> FsEventRefWrapper {
+        let ptr = raw as SafePointer;
+        Self {
+            ptr
+        }
+    }
+}
+
+impl From<FsEventRefWrapper> for *mut ::std::os::raw::c_void {
+    fn from(safe: FsEventRefWrapper) -> *mut ::std::os::raw::c_void {
+        safe.ptr as *mut ::std::os::raw::c_void
+    }
+}
+
 pub struct FsEvent {
-    paths: cf::CFMutableArrayRef,
+    paths: Vec<String>,
     since_when: fs::FSEventStreamEventId,
     latency: cf::CFTimeInterval,
     flags: fs::FSEventStreamCreateFlags,
-    sender: Sender<Event>,
 }
 
 #[derive(Debug)]
@@ -140,8 +165,8 @@ impl std::fmt::Display for StreamFlags {
     }
 }
 
-fn default_stream_context(info: *const FsEvent) -> fs::FSEventStreamContext {
-    let ptr = info as *mut ::std::os::raw::c_void;
+fn default_stream_context(event_sender: *const Sender<Event>) -> fs::FSEventStreamContext {
+    let ptr = event_sender as *mut ::std::os::raw::c_void;
     fs::FSEventStreamContext {
         version: 0,
         info: ptr,
@@ -180,69 +205,99 @@ impl From<std::sync::mpsc::RecvTimeoutError> for Error {
 }
 
 impl FsEvent {
-    pub fn new(sender: Sender<Event>) -> FsEvent {
-        let fsevent: FsEvent;
+    pub fn new(paths: Vec<String>) -> Self {
 
-        unsafe {
-            fsevent = FsEvent {
-                paths: FsEventHandle::from(cf::CFArrayCreateMutable(
-                    cf::kCFAllocatorDefault,
-                    0,
-                    &cf::kCFTypeArrayCallBacks,
-                )),
-                since_when: fs::kFSEventStreamEventIdSinceNow,
-                latency: 0.0,
-                flags: fs::kFSEventStreamCreateFlagFileEvents | fs::kFSEventStreamCreateFlagNoDefer,
-                sender,
-            };
+        Self {
+            paths,
+            since_when: fs::kFSEventStreamEventIdSinceNow,
+            latency: 0.0,
+            flags: fs::kFSEventStreamCreateFlagFileEvents | fs::kFSEventStreamCreateFlagNoDefer,
         }
-        fsevent
     }
 
     // https://github.com/thibaudgg/rb-fsevent/blob/master/ext/fsevent_watch/main.c
-    pub fn append_path(&self, source: &str) -> Result<()> {
-        unsafe {
-            let mut err = ptr::null_mut();
-            let cf_path = cf::str_path_to_cfstring_ref(source, &mut err);
-            if !err.is_null() {
-                let cf_str = cf::CFCopyDescription(err as cf::CFRef);
-                let mut buf = [0; 1024];
-                cf::CFStringGetCString(
-                    cf_str,
-                    buf.as_mut_ptr(),
-                    buf.len() as cf::CFIndex,
-                    cf::kCFStringEncodingUTF8,
-                );
-                Err(Error {
-                    msg: CStr::from_ptr(buf.as_ptr())
-                        .to_str()
-                        .unwrap_or("Unknown error")
-                        .to_string(),
-                })
-            } else {
-                cf::CFArrayAppendValue(self.paths, cf_path);
-                cf::CFRelease(cf_path);
-                Ok(())
-            }
-        }
+    pub fn append_path(&mut self, source: &str) -> Result<()> {
+        self.paths.push(source.to_string());
+        Ok(())
     }
-    pub fn observe(&self) {
-        let stream_context = default_stream_context(self);
 
+    fn build_native_paths(&self) -> Result<cf::CFMutableArrayRef> {
+        let native_paths = unsafe {
+            cf::CFArrayCreateMutable(
+                cf::kCFAllocatorDefault,
+                0,
+                &cf::kCFTypeArrayCallBacks)
+        };
+
+        if native_paths == std::ptr::null_mut() {
+            Err(Error {
+                msg: "Unable to allocate CFMutableArrayRef".to_string()
+            })
+        } else {
+            for path in &self.paths {
+                unsafe {
+                    let mut err = ptr::null_mut();
+                    let cf_path = cf::str_path_to_cfstring_ref(path, &mut err);
+                    if !err.is_null() {
+                        let cf_str = cf::CFCopyDescription(err as cf::CFRef);
+                        let mut buf = [0; 1024];
+                        cf::CFStringGetCString(
+                            cf_str,
+                            buf.as_mut_ptr(),
+                            buf.len() as cf::CFIndex,
+                            cf::kCFStringEncodingUTF8,
+                        );
+                        return Err(Error {
+                            msg: CStr::from_ptr(buf.as_ptr())
+                                .to_str()
+                                .unwrap_or("Unknown error")
+                                .to_string(),
+                        })
+                    } else {
+                        cf::CFArrayAppendValue(native_paths, cf_path);
+                        cf::CFRelease(cf_path);
+                    }
+                }
+            }
+
+            Ok(native_paths)
+        }
+
+    }
+
+    fn internal_observe(since_when: fs::FSEventStreamEventId,
+                        latency: cf::CFTimeInterval,
+                        flags: fs::FSEventStreamCreateFlags,
+                        paths: FsEventRefWrapper,
+                        event_sender: Sender<Event>,
+                        subscription_handle_sender: Option<Sender<FsEventRefWrapper>>) -> Result<()>
+    {
+        let stream_context = default_stream_context(&event_sender);
         let cb = callback as *mut _;
+        let paths = paths.into();
 
         unsafe {
             let stream = fs::FSEventStreamCreate(
                 cf::kCFAllocatorDefault,
                 cb,
                 &stream_context,
-                self.paths,
-                self.since_when,
-                self.latency,
-                self.flags,
+                paths,
+                since_when,
+                latency,
+                flags,
             );
 
             // fs::FSEventStreamShow(stream);
+
+            match subscription_handle_sender {
+                Some(ret_tx) => {
+                    let runloop_ref = cf::CFRunLoopGetCurrent();
+                    let runloop_ref_safe = FsEventRefWrapper::from(runloop_ref);
+                    let ptr_val = runloop_ref_safe.ptr.clone();
+                    ret_tx.send(runloop_ref_safe).expect(&format!("Unable to return CFRunLoopRef ({:#X})", ptr_val));
+                }
+                None => {}
+            }
 
             fs::FSEventStreamScheduleWithRunLoop(
                 stream,
@@ -256,51 +311,36 @@ impl FsEvent {
             fs::FSEventStreamFlushSync(stream);
             fs::FSEventStreamStop(stream);
         }
+
+        Ok(())
     }
 
-    pub fn observe_async(&self) -> Result<FsEventHandle> {
+    pub fn observe(&self, event_sender: Sender<Event>) {
+        let native_paths = self.build_native_paths().expect("Unable to build CFMutableArrayRef of watched paths.");
+        let safe_native_paths = FsEventRefWrapper::from(native_paths);
+        Self::internal_observe(self.since_when, self.latency, self.flags, safe_native_paths, event_sender, None).unwrap();
+    }
+
+    pub fn observe_async(&self, event_sender: Sender<Event>) -> Result<FsEventRefWrapper> {
         let (ret_tx, ret_rx) = std::sync::mpsc::channel();
+        let native_paths = self.build_native_paths()?;
+        let safe_native_paths = FsEventRefWrapper::from(native_paths);
 
+        let since_when = self.since_when;
+        let latency = self.latency;
+        let flags = self.flags;
         std::thread::spawn(move || {
-            let stream_context = default_stream_context(self);
-
-            let cb = callback as *mut _;
-
-            unsafe {
-                let stream = fs::FSEventStreamCreate(
-                    cf::kCFAllocatorDefault,
-                    cb,
-                    &stream_context,
-                    self.paths.into(),
-                    self.since_when,
-                    self.latency,
-                    self.flags,
-                );
-
-                // fs::FSEventStreamShow(stream);
-
-                let runloop_ref = cf::CFRunLoopGetCurrent();
-                let runloop_ref_safe = FsEventHandle::from(runloop_ref);
-                ret_tx.send(runloop_ref_safe).expect(&format!("Unable to return CFRunLoopRef ({:#X})", runloop_ref_safe.ptr));
-
-                fs::FSEventStreamScheduleWithRunLoop(
-                    stream,
-                    cf::CFRunLoopGetCurrent(),
-                    cf::kCFRunLoopDefaultMode,
-                );
-
-                fs::FSEventStreamStart(stream);
-                cf::CFRunLoopRun();
-
-                fs::FSEventStreamFlushSync(stream);
-                fs::FSEventStreamStop(stream);
-            }
+            Self::internal_observe(since_when, latency, flags, safe_native_paths, event_sender, Some(ret_tx))
         });
 
         match ret_rx.recv_timeout(std::time::Duration::from_secs(5)) {
             Ok(v) => Ok(v),
             Err(e) => Err(Error::from(e))
         }
+    }
+
+    pub fn shutdown_observe(&self, handle: FsEventRefWrapper) {
+        unsafe { cf::CFRunLoopStop(handle.into()) };
     }
 }
 
@@ -316,7 +356,7 @@ unsafe fn callback(
     let num = num_events;
     let e_ptr = event_flags as *mut u32;
     let i_ptr = event_ids as *mut u64;
-    let fs_event = info as *mut FsEvent;
+    let sender = info as *mut Sender<Event>;
 
     let paths: &[*const ::std::os::raw::c_char] =
         std::mem::transmute(slice::from_raw_parts(event_paths, num));
@@ -335,6 +375,6 @@ unsafe fn callback(
             flag,
             path: path.to_string(),
         };
-        let _s = (*fs_event).sender.send(event);
+        let _s = (*sender).send(event);
     }
 }

--- a/tests/fsevent.rs
+++ b/tests/fsevent.rs
@@ -102,7 +102,7 @@ fn observe_folder() {
 
     {
         let _t = thread::spawn(move || {
-            let fsevent = fsevent::FsEvent::new(sender);
+            let mut fsevent = fsevent::FsEvent::new(vec![]);
             fsevent
                 .append_path(dst1.as_path().to_str().unwrap())
                 .unwrap();
@@ -112,7 +112,7 @@ fn observe_folder() {
             fsevent
                 .append_path(dst3.as_path().to_str().unwrap())
                 .unwrap();
-            fsevent.observe();
+            fsevent.observe(sender);
         });
     }
 
@@ -155,11 +155,11 @@ fn validate_watch_single_file() {
     {
         let dst = dst.clone();
         let _t = thread::spawn(move || {
-            let fsevent = fsevent::FsEvent::new(sender);
+            let mut fsevent = fsevent::FsEvent::new(vec![]);
             fsevent
                 .append_path(dst.as_path().to_str().unwrap())
                 .unwrap();
-            fsevent.observe();
+            fsevent.observe(sender);
         });
     }
 


### PR DESCRIPTION
This change introduces a breaking change to the FsEvent API in order to support an async form of FsEvent::observe. In order to achieve this, struct members that are not `Sync + Send` were removed. These included the `std::sync::mspc::Sender` and the `cf::CFMutableArrayRef` members.

Instead of creating the `CFMutableArrayRef` at FsEvent construction, we wait till `observe` or `observe_async` is called to construct it. This allows callers to still use `append_path` and we update an internal `Vec<String>`.

Unfortunately, I had to remove `std::sync::mspc::Sender` from the `new` call since it can't be a struct member. Instead, this item is passed in on the call to `observe`/`observe_async`.

Where possible, I've tried to not disrupt the API significantly. Additionally, I've updated the tests to run an async version in addition to the original sync form. I've also added an example of an async FsEvent observer.

PS: I updated the .editorconfig - it was set to spacing of "2" but all files were formatted as "4" for tabs.