### PR TITLE
fix some ffi bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fsevent"
-version = "1.0.1"
+version = "1.0.2"
 authors = [ "Pierre Baillet <pierre@baillet.name>" ]
 description = "Rust bindings to the fsevent-sys macOS API for file changes notifications"
 license="MIT"
@@ -9,7 +9,7 @@ repository = "https://github.com/octplane/fsevent-rust"
 
 [dependencies]
 bitflags = "1"
-fsevent-sys = "2.0.1"
+fsevent-sys = "2.1.0"
 
 [dev-dependencies]
 tempdir = "^0.3.4"

--- a/fsevent-sys/Cargo.toml
+++ b/fsevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsevent-sys"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["Pierre Baillet <pierre@baillet.name>"]
 description = "Rust bindings to the fsevent macOS API for file changes notifications"
 license = "MIT"

--- a/fsevent-sys/src/fsevent.rs
+++ b/fsevent-sys/src/fsevent.rs
@@ -5,19 +5,19 @@ use core_foundation as cf;
 pub type FSEventStreamRef = *mut ::std::os::raw::c_void;
 
 pub type FSEventStreamCallback = extern "C" fn(
-    FSEventStreamRef,            //ConstFSEventStreamRef streamRef
-    *mut ::std::os::raw::c_void, // void *clientCallBackInfo
-    usize,                       // size_t numEvents
-    *mut ::std::os::raw::c_void, // void *eventPaths
-    *mut ::std::os::raw::c_void, // const FSEventStreamEventFlags eventFlags[]
-    *mut ::std::os::raw::c_void, // const FSEventStreamEventId eventIds[]
+    FSEventStreamRef,              // ConstFSEventStreamRef streamRef
+    *mut ::std::os::raw::c_void,   // void *clientCallBackInfo
+    usize,                         // size_t numEvents
+    *mut ::std::os::raw::c_void,   // void *eventPaths
+    *const ::std::os::raw::c_void, // const FSEventStreamEventFlags eventFlags[]
+    *const ::std::os::raw::c_void, // const FSEventStreamEventId eventIds[]
 );
 
 pub type FSEventStreamEventId = u64;
 
 pub const kFSEventStreamEventIdSinceNow: FSEventStreamEventId = 0xFFFFFFFFFFFFFFFF;
 
-pub type FSEventStreamCreateFlags = u32;
+pub type FSEventStreamCreateFlags = std::os::raw::c_uint;
 
 pub const kFSEventStreamCreateFlagNone: FSEventStreamCreateFlags = 0x00000000;
 pub const kFSEventStreamCreateFlagUseCFTypes: FSEventStreamCreateFlags = 0x00000001;
@@ -28,7 +28,7 @@ pub const kFSEventStreamCreateFlagFileEvents: FSEventStreamCreateFlags = 0x00000
 pub const kFSEventStreamCreateFlagMarkSelf: FSEventStreamCreateFlags = 0x00000020;
 pub const kFSEventStreamCreateFlagUseExtendedData: FSEventStreamCreateFlags = 0x00000040;
 
-pub type FSEventStreamEventFlags = u32;
+pub type FSEventStreamEventFlags = std::os::raw::c_uint;
 
 pub const kFSEventStreamEventFlagNone: FSEventStreamEventFlags = 0x00000000;
 pub const kFSEventStreamEventFlagMustScanSubDirs: FSEventStreamEventFlags = 0x00000001;
@@ -59,18 +59,18 @@ pub const kFSEventStreamEventFlagItemCloned: FSEventStreamEventFlags = 0x0040000
 pub struct FSEventStreamContext {
     pub version: cf::CFIndex,
     pub info: *mut ::std::os::raw::c_void,
-    pub retain: *mut ::std::os::raw::c_void,
-    pub copy_description: *mut ::std::os::raw::c_void,
+    pub retain: Option<cf::CFAllocatorRetainCallBack>,
+    pub release: Option<cf::CFAllocatorReleaseCallBack>,
+    pub copy_description: Option<cf::CFAllocatorCopyDescriptionCallBack>,
 }
 // impl Clone for FSEventStreamContext { }
 // impl Copy for FSEventStreamContext { }
 
 #[link(name = "CoreServices", kind = "framework")]
 extern "C" {
-
     pub fn FSEventStreamCreate(
-        allocator: cf::CFRef,
-        callback: *const FSEventStreamCallback,
+        allocator: cf::CFAllocatorRef,
+        callback: FSEventStreamCallback,
         context: *const FSEventStreamContext,
         pathsToWatch: cf::CFMutableArrayRef,
         sinceWhen: FSEventStreamEventId,
@@ -91,10 +91,9 @@ extern "C" {
         run_loop_mode: cf::CFStringRef,
     );
 
-    pub fn FSEventStreamStart(stream_ref: FSEventStreamRef) -> bool;
+    pub fn FSEventStreamStart(stream_ref: FSEventStreamRef) -> cf::Boolean;
     pub fn FSEventStreamFlushSync(stream_ref: FSEventStreamRef);
     pub fn FSEventStreamStop(stream_ref: FSEventStreamRef);
     pub fn FSEventStreamInvalidate(stream_ref: FSEventStreamRef);
     pub fn FSEventStreamRelease(stream_ref: FSEventStreamRef);
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,9 @@ fn default_stream_context(event_sender: *const Sender<Event>) -> fs::FSEventStre
     fs::FSEventStreamContext {
         version: 0,
         info: ptr,
-        retain: cf::NULL,
-        copy_description: cf::NULL,
+        retain: None,
+        release: None,
+        copy_description: None,
     }
 }
 
@@ -267,13 +268,12 @@ impl FsEvent {
         subscription_handle_sender: Option<Sender<FsEventRefWrapper>>,
     ) -> Result<()> {
         let stream_context = default_stream_context(&event_sender);
-        let cb = callback as *mut _;
         let paths = paths.into();
 
         unsafe {
             let stream = fs::FSEventStreamCreate(
                 cf::kCFAllocatorDefault,
-                cb,
+                callback,
                 &stream_context,
                 paths,
                 since_when,
@@ -356,36 +356,39 @@ impl FsEvent {
 }
 
 #[allow(unused_variables)]
-unsafe fn callback(
+extern "C" fn callback(
     stream_ref: fs::FSEventStreamRef,
     info: *mut ::std::os::raw::c_void,
-    num_events: usize,                                 // size_t numEvents
-    event_paths: *const *const ::std::os::raw::c_char, // void *eventPaths
-    event_flags: *mut ::std::os::raw::c_void,          // const FSEventStreamEventFlags eventFlags[]
-    event_ids: *mut ::std::os::raw::c_void,            // const FSEventStreamEventId eventIds[]
+    num_events: usize,                          // size_t numEvents
+    event_paths: *mut ::std::os::raw::c_void,   // void *eventPaths
+    event_flags: *const ::std::os::raw::c_void, // const FSEventStreamEventFlags eventFlags[]
+    event_ids: *const ::std::os::raw::c_void,   // const FSEventStreamEventId eventIds[]
 ) {
-    let num = num_events;
-    let e_ptr = event_flags as *mut u32;
-    let i_ptr = event_ids as *mut u64;
-    let sender = info as *mut Sender<Event>;
+    unsafe {
+        let event_paths = event_paths as *const *const ::std::os::raw::c_char;
+        let num = num_events;
+        let e_ptr = event_flags as *mut u32;
+        let i_ptr = event_ids as *mut u64;
+        let sender = info as *mut Sender<Event>;
 
-    let paths: &[*const ::std::os::raw::c_char] =
-        std::mem::transmute(slice::from_raw_parts(event_paths, num));
-    let flags = from_raw_parts_mut(e_ptr, num);
-    let ids = from_raw_parts_mut(i_ptr, num);
+        let paths: &[*const ::std::os::raw::c_char] =
+            std::mem::transmute(slice::from_raw_parts(event_paths, num));
+        let flags = from_raw_parts_mut(e_ptr, num);
+        let ids = from_raw_parts_mut(i_ptr, num);
 
-    for p in 0..num {
-        let i = CStr::from_ptr(paths[p]).to_bytes();
-        let path = from_utf8(i).expect("Invalid UTF8 string.");
-        let flag: StreamFlags = StreamFlags::from_bits(flags[p])
-            .expect(format!("Unable to decode StreamFlags: {} for {}", flags[p], path).as_ref());
-        // println!("{}: {}", ids[p], flag);
+        for p in 0..num {
+            let i = CStr::from_ptr(paths[p]).to_bytes();
+            let path = from_utf8(i).expect("Invalid UTF8 string.");
+            let flag: StreamFlags = StreamFlags::from_bits(flags[p])
+                .expect(format!("Unable to decode StreamFlags: {} for {}", flags[p], path).as_ref());
+            // println!("{}: {}", ids[p], flag);
 
-        let event = Event {
-            event_id: ids[p],
-            flag,
-            path: path.to_string(),
-        };
-        let _s = (*sender).send(event);
+            let event = Event {
+                event_id: ids[p],
+                flag,
+                path: path.to_string(),
+            };
+            let _s = (*sender).send(event);
+        }
     }
 }


### PR DESCRIPTION
I have bumped the versions in both `fsevent` and `fsevent-sys`.

Mostly this PR fixes bugs in `fsevent-sys` because I do not depend on `fsevent` directly.
Here's a listing of ffi bugs in `fsevent-sys`.

- `CFURLPathStyle` is now defined as `CFIndex` not `c_uint`.
- `CFComparisonResult` is now defined as `CFIndex` not `i32`.
- `CFStringCompareFlags` is now defined as an `c_ulong` not a `u32`.
- `CFArrayCallBacks` contains function pointers not `CFRef`'s.
- The last two pointer arguments in `FSEventStreamCallback` are `const`.
- `FSEventStreamCreateFlags` is now defined as a `c_uint` not a `u32`.
- `FSEventStreamEventFlags` is now defined as a `c_uint` not a `u32`.
- `FSEventStreamContext` was missing a member, `release`.
- `FSEventStreamStart` returns a `Boolean` not a `bool`.
- `FSEventStreamCreate`'s second parameter is a `FSEventStreamCallback`, not a pointer to a `FSEventStreamCallback`.