### PR TITLE
rust 1.26.1 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fsevent"
-version = "2.0.0"
+version = "2.0.1"
 authors = [ "Pierre Baillet <pierre@baillet.name>" ]
 description = "Rust bindings to the fsevent-sys macOS API for file changes notifications"
 license="MIT"
@@ -9,7 +9,7 @@ repository = "https://github.com/octplane/fsevent-rust"
 
 [dependencies]
 bitflags = "1"
-fsevent-sys = "3.0.0"
+fsevent-sys = "3.0.1"
 
 [dev-dependencies]
 tempdir = "^0.3.4"

--- a/fsevent-sys/Cargo.toml
+++ b/fsevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsevent-sys"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Pierre Baillet <pierre@baillet.name>"]
 description = "Rust bindings to the fsevent macOS API for file changes notifications"
 license = "MIT"

--- a/fsevent-sys/src/core_foundation.rs
+++ b/fsevent-sys/src/core_foundation.rs
@@ -6,7 +6,7 @@ use std::ffi::CString;
 use std::ptr;
 use std::str;
 
-pub type Boolean = std::os::raw::c_uchar;
+pub type Boolean = ::std::os::raw::c_uchar;
 
 pub type CFRef = *mut ::std::os::raw::c_void;
 
@@ -27,10 +27,10 @@ pub const NULL: CFRef = 0 as CFRef;
 pub const NULL_REF_PTR: *mut CFRef = 0 as *mut CFRef;
 
 pub type CFAllocatorRetainCallBack =
-    extern "C" fn(*const std::os::raw::c_void) -> *const std::os::raw::c_void;
-pub type CFAllocatorReleaseCallBack = extern "C" fn(*const std::os::raw::c_void);
+    extern "C" fn(*const ::std::os::raw::c_void) -> *const ::std::os::raw::c_void;
+pub type CFAllocatorReleaseCallBack = extern "C" fn(*const ::std::os::raw::c_void);
 pub type CFAllocatorCopyDescriptionCallBack =
-    extern "C" fn(*const std::os::raw::c_void) -> *const CFStringRef;
+    extern "C" fn(*const ::std::os::raw::c_void) -> *const CFStringRef;
 
 pub type CFURLPathStyle = CFIndex;
 
@@ -47,14 +47,14 @@ pub type CFComparisonResult = CFIndex;
 
 // MacOS uses Case Insensitive path
 pub const kCFCompareCaseInsensitive: CFStringCompareFlags = 1;
-pub type CFStringCompareFlags = std::os::raw::c_ulong;
+pub type CFStringCompareFlags = ::std::os::raw::c_ulong;
 
 pub type CFArrayRetainCallBack =
-    extern "C" fn(CFAllocatorRef, *const std::os::raw::c_void) -> *const std::os::raw::c_void;
-pub type CFArrayReleaseCallBack = extern "C" fn(CFAllocatorRef, *const std::os::raw::c_void);
-pub type CFArrayCopyDescriptionCallBack = extern "C" fn(*const std::os::raw::c_void) -> CFStringRef;
+    extern "C" fn(CFAllocatorRef, *const ::std::os::raw::c_void) -> *const ::std::os::raw::c_void;
+pub type CFArrayReleaseCallBack = extern "C" fn(CFAllocatorRef, *const ::std::os::raw::c_void);
+pub type CFArrayCopyDescriptionCallBack = extern "C" fn(*const ::std::os::raw::c_void) -> CFStringRef;
 pub type CFArrayEqualCallBack =
-    extern "C" fn(*const std::os::raw::c_void, *const std::os::raw::c_void) -> Boolean;
+    extern "C" fn(*const ::std::os::raw::c_void, *const ::std::os::raw::c_void) -> Boolean;
 
 #[repr(C)]
 pub struct CFArrayCallBacks {

--- a/fsevent-sys/src/fsevent.rs
+++ b/fsevent-sys/src/fsevent.rs
@@ -17,7 +17,7 @@ pub type FSEventStreamEventId = u64;
 
 pub const kFSEventStreamEventIdSinceNow: FSEventStreamEventId = 0xFFFFFFFFFFFFFFFF;
 
-pub type FSEventStreamCreateFlags = std::os::raw::c_uint;
+pub type FSEventStreamCreateFlags = ::std::os::raw::c_uint;
 
 pub const kFSEventStreamCreateFlagNone: FSEventStreamCreateFlags = 0x00000000;
 pub const kFSEventStreamCreateFlagUseCFTypes: FSEventStreamCreateFlags = 0x00000001;
@@ -28,7 +28,7 @@ pub const kFSEventStreamCreateFlagFileEvents: FSEventStreamCreateFlags = 0x00000
 pub const kFSEventStreamCreateFlagMarkSelf: FSEventStreamCreateFlags = 0x00000020;
 pub const kFSEventStreamCreateFlagUseExtendedData: FSEventStreamCreateFlags = 0x00000040;
 
-pub type FSEventStreamEventFlags = std::os::raw::c_uint;
+pub type FSEventStreamEventFlags = ::std::os::raw::c_uint;
 
 pub const kFSEventStreamEventFlagNone: FSEventStreamEventFlags = 0x00000000;
 pub const kFSEventStreamEventFlagMustScanSubDirs: FSEventStreamEventFlags = 0x00000001;


### PR DESCRIPTION
Adds `::` to the front of all `std` namespaces.

My previous PR did not do that, but this is important for downstream crates that want to guarantee support for older rust versions.

This also bumps the patch version, as the API has not changed, and no new features have been added.