### PR TITLE
support for building on non-macos systems

### DIFF
--- a/fsevent-sys/src/lib.rs
+++ b/fsevent-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(target_arch = "macOS")]
 #![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 
 pub mod core_foundation;


### PR DESCRIPTION
I'm trying to package this crate for debian, since other crates that I want to package depend on it, and it would be convenient if the package didn't give build errors on linux systems.