### PR TITLE
Make sure that 'cargo test' can run on non-macos systems

### DIFF
--- a/examples/fsevent-async-demo.rs
+++ b/examples/fsevent-async-demo.rs
@@ -3,6 +3,10 @@ extern crate fsevent;
 use std::sync::mpsc::channel;
 use std::thread;
 
+#[cfg(not(target_arch = "macOS"))]
+fn main() {}
+
+#[cfg(target_arch = "macOS")]
 fn main() {
     let (sender, receiver) = channel();
 

--- a/examples/fsevent-demo.rs
+++ b/examples/fsevent-demo.rs
@@ -2,6 +2,10 @@ extern crate fsevent;
 use std::sync::mpsc::channel;
 use std::thread;
 
+#[cfg(not(target_arch = "macOS"))]
+fn main() {}
+
+#[cfg(target_arch = "macOS")]
 fn main() {
     let (sender, receiver) = channel();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(target_arch = "macOS")]
 #![deny(
     trivial_numeric_casts,
     unstable_features,

--- a/tests/fsevent.rs
+++ b/tests/fsevent.rs
@@ -1,3 +1,4 @@
+#![cfg(target_arch = "macOS")]
 extern crate fsevent;
 extern crate tempfile;
 extern crate time;


### PR DESCRIPTION
with the help of config macros