### PR TITLE
Link CoreFoundation directly

### DIFF
--- a/fsevent-sys/src/core_foundation.rs
+++ b/fsevent-sys/src/core_foundation.rs
@@ -66,7 +66,7 @@ pub struct CFArrayCallBacks {
 }
 //impl Clone for CFArrayCallBacks { }
 
-#[link(name = "CoreServices", kind = "framework")]
+#[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {
     pub static kCFTypeArrayCallBacks: CFArrayCallBacks;
     pub static kCFRunLoopDefaultMode: CFStringRef;


### PR DESCRIPTION
Currently the `core_foundation` module links the `CoreServices` framework (which indirectly links `CoreFoundation`).

When building with stricter reproducibility (using [nix](https://nixos.org/nix)) this causes a link-time failure. Directly linking `CoreFoundation` instead fixes the issue for me.