### PR TITLE
Fix some leaks and types in fsevent-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ name = "fsevent"
 version = "2.0.2"
 authors = [ "Pierre Baillet <pierre@baillet.name>" ]
 description = "Rust bindings to the fsevent-sys macOS API for file changes notifications"
-license="MIT"
+license = "MIT"
 repository = "https://github.com/octplane/fsevent-rust"
+edition = "2018"
 
 [dependencies]
 bitflags = "1"
-fsevent-sys = "3.0.2"
-# fsevent-sys = { "path" = "fsevent-sys" }
+fsevent-sys = { path = "fsevent-sys" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/fsevent-sys/src/core_foundation.rs
+++ b/fsevent-sys/src/core_foundation.rs
@@ -158,9 +158,9 @@ pub unsafe fn str_path_to_cfstring_ref(source: &str, err: &mut CFErrorRef) -> CF
     let mut placeholder = CFURLCopyAbsoluteURL(url);
     CFRelease(url);
 
-    let mut imaginary = ptr::null_mut();
+    let mut imaginary: CFRef = ptr::null_mut();
 
-    while !CFURLResourceIsReachable(placeholder.0, ptr::null_mut()) {
+    while !CFURLResourceIsReachable(placeholder, ptr::null_mut()) {
         if imaginary.is_null() {
             imaginary = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
             if imaginary.is_null() {

--- a/fsevent-sys/src/fsevent.rs
+++ b/fsevent-sys/src/fsevent.rs
@@ -9,8 +9,8 @@ pub type FSEventStreamCallback = extern "C" fn(
     *mut ::std::os::raw::c_void,   // void *clientCallBackInfo
     usize,                         // size_t numEvents
     *mut ::std::os::raw::c_void,   // void *eventPaths
-    *const ::std::os::raw::c_void, // const FSEventStreamEventFlags eventFlags[]
-    *const ::std::os::raw::c_void, // const FSEventStreamEventId eventIds[]
+    *const FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+    *const FSEventStreamEventId, // const FSEventStreamEventId eventIds[]
 );
 
 pub type FSEventStreamEventId = u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ extern crate fsevent_sys as fsevent;
 use fsevent as fs;
 use fsevent::core_foundation as cf;
 
-use std::convert::AsRef;
 use std::ffi::CStr;
 use std::ptr;
 use std::slice;
@@ -385,8 +384,8 @@ extern "C" fn callback(
         for p in 0..num {
             let i = CStr::from_ptr(paths[p]).to_bytes();
             let path = from_utf8(i).expect("Invalid UTF8 string.");
-            let flag: StreamFlags = StreamFlags::from_bits(flags[p]).expect(
-                format!("Unable to decode StreamFlags: {} for {}", flags[p], path).as_ref(),
+            let flag: StreamFlags = StreamFlags::from_bits(flags[p]).unwrap_or_else(||
+                panic!("Unable to decode StreamFlags: {} for {}", flags[p], path)
             );
             // println!("{}: {}", ids[p], flag);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,8 @@ use fsevent as fs;
 use fsevent::core_foundation as cf;
 
 use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
 use std::ptr;
-use std::slice;
-use std::slice::from_raw_parts_mut;
-use std::str::from_utf8;
 
 use std::sync::mpsc::Sender;
 
@@ -363,35 +361,27 @@ impl FsEvent {
 #[allow(unused_variables)]
 extern "C" fn callback(
     stream_ref: fs::FSEventStreamRef,
-    info: *mut ::std::os::raw::c_void,
-    num_events: usize,                          // size_t numEvents
-    event_paths: *mut ::std::os::raw::c_void,   // void *eventPaths
-    event_flags: *const ::std::os::raw::c_void, // const FSEventStreamEventFlags eventFlags[]
-    event_ids: *const ::std::os::raw::c_void,   // const FSEventStreamEventId eventIds[]
+    info: *mut c_void,
+    num_events: usize,                               // size_t numEvents
+    event_paths: *mut c_void,                        // void *eventPaths
+    event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+    event_ids: *const fs::FSEventStreamEventId,      // const FSEventStreamEventId eventIds[]
 ) {
     unsafe {
-        let event_paths = event_paths as *const *const ::std::os::raw::c_char;
-        let num = num_events;
-        let e_ptr = event_flags as *mut u32;
-        let i_ptr = event_ids as *mut u64;
         let sender = info as *mut Sender<Event>;
 
-        let paths: &[*const ::std::os::raw::c_char] =
-            std::mem::transmute(slice::from_raw_parts(event_paths, num));
-        let flags = from_raw_parts_mut(e_ptr, num);
-        let ids = from_raw_parts_mut(i_ptr, num);
-
-        for p in 0..num {
-            let i = CStr::from_ptr(paths[p]).to_bytes();
-            let path = from_utf8(i).expect("Invalid UTF8 string.");
-            let flag: StreamFlags = StreamFlags::from_bits(flags[p]).unwrap_or_else(||
-                panic!("Unable to decode StreamFlags: {} for {}", flags[p], path)
-            );
-            // println!("{}: {}", ids[p], flag);
+        for pos in 0..num_events {
+            let path = CStr::from_ptr(event_paths.add(pos) as *const c_char)
+                .to_str()
+                .expect("Invalid UTF8 string.");
+            let flag = *event_flags.add(pos);
+            let event_id = *event_ids.add(pos);
 
             let event = Event {
-                event_id: ids[p],
-                flag,
+                event_id,
+                flag: StreamFlags::from_bits(flag).unwrap_or_else(|| {
+                    panic!("Unable to decode StreamFlags: {} for {}", flag, path)
+                }),
                 path: path.to_string(),
             };
             let _s = (*sender).send(event);

--- a/tests/fsevent.rs
+++ b/tests/fsevent.rs
@@ -32,10 +32,7 @@ fn validate_recv(rx: Receiver<Event>, evs: Vec<(String, StreamFlags)>) {
             if let Some(i) = found {
                 evs.remove(i);
             } else {
-                assert!(
-                    false,
-                    format!("actual: {:?} not found in expected: {:?}", actual, evs)
-                );
+                panic!("actual: {:?} not found in expected: {:?}", actual, evs);
             }
         }
         if evs.is_empty() {


### PR DESCRIPTION
As best as I can tell, `CFURLCreateFileReferenceURL` and `CFURLCreateFilePathURL`
do not free the passed in url upon error. This change makes sure we release the
url on success or failure.