### PR TITLE
Bump a major version for fsevent-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fsevent"
-version = "2.1.0"
+version = "2.1.1"
 authors = [ "Pierre Baillet <pierre@baillet.name>" ]
 description = "Rust bindings to the fsevent-sys macOS API for file changes notifications"
 license = "MIT"
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1"
-fsevent-sys = "3.2.0"
+fsevent-sys = "4.0.0"
 # fsevent-sys = { path = "fsevent-sys" }
 
 [dev-dependencies]

--- a/fsevent-sys/Cargo.toml
+++ b/fsevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsevent-sys"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Pierre Baillet <pierre@baillet.name>"]
 description = "Rust bindings to the fsevent macOS API for file changes notifications"
 license = "MIT"


### PR DESCRIPTION
I forgot to call out that I made a breaking change to fsevent-sys, which
broke `notify`. This makes a major version bump to avoid this issue.

Also, I'd recomment `cargo yank`-ing fsevent-sys 3.2.0 and fsevent 2.1.0 to
fix downstream users.

Closes #36