### PR TITLE
Add `kFSEventStreamCreateFlagFullHistory`

### DIFF
--- a/fsevent-sys/src/fsevent.rs
+++ b/fsevent-sys/src/fsevent.rs
@@ -30,6 +30,7 @@ pub const kFSEventStreamCreateFlagIgnoreSelf: FSEventStreamCreateFlags = 0x00000
 pub const kFSEventStreamCreateFlagFileEvents: FSEventStreamCreateFlags = 0x00000010;
 pub const kFSEventStreamCreateFlagMarkSelf: FSEventStreamCreateFlags = 0x00000020;
 pub const kFSEventStreamCreateFlagUseExtendedData: FSEventStreamCreateFlags = 0x00000040;
+pub const kFSEventStreamCreateFlagFullHistory: FSEventStreamCreateFlags = 0x00000080;
 
 pub const kFSEventStreamEventFlagNone: FSEventStreamEventFlags = 0x00000000;
 pub const kFSEventStreamEventFlagMustScanSubDirs: FSEventStreamEventFlags = 0x00000001;


### PR DESCRIPTION
```txt
  /*
   * When requesting historical events it is possible that some events
   * may get skipped due to the way they are stored.  With this flag
   * all historical events in a given chunk are returned even if their
   * event-id is less than the sinceWhen id.  Put another way, deliver
   * all the events in the first chunk of historical events that contains
   * the sinceWhen id so that none are skipped even if their id is less
   * than the sinceWhen id.  This overlap avoids any issue with missing
   * events that happened at/near the time of an unclean restart of the
   * client process.
   */
  kFSEventStreamCreateFlagFullHistory __OSX_AVAILABLE_STARTING(__MAC_10_15, __IPHONE_13_0) = 0x00000080,
```