### PR TITLE
Add `FSEventStreamSetDispatchQueue`, clippy fix

### DIFF
--- a/fsevent-sys/Cargo.toml
+++ b/fsevent-sys/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/octplane/fsevent-rust/tree/master/fsevent-sys"
 edition = "2018"
 
 [dependencies]
+dispatch2 = { version = "0.2.0", default-features = false, features = ["alloc"] }
 libc = "0.2.68"
 
 [package.metadata.docs.rs]

--- a/fsevent-sys/src/core_foundation.rs
+++ b/fsevent-sys/src/core_foundation.rs
@@ -148,7 +148,7 @@ extern "C" {
 
 pub unsafe fn str_path_to_cfstring_ref(source: &str, err: &mut CFErrorRef) -> CFStringRef {
     let c_path = CString::new(source).unwrap();
-    let c_len = libc::strlen(c_path.as_ptr());
+    let c_len = c_path.as_bytes().len();
     let mut url = CFURLCreateFromFileSystemRepresentation(
         kCFAllocatorDefault,
         c_path.as_ptr(),

--- a/fsevent-sys/src/fsevent.rs
+++ b/fsevent-sys/src/fsevent.rs
@@ -5,6 +5,7 @@ use crate::core_foundation::{
     CFAllocatorReleaseCallBack, CFAllocatorRetainCallBack, CFArrayRef, CFIndex, CFRunLoopRef,
     CFStringRef, CFTimeInterval,
 };
+use dispatch2::ffi::dispatch_queue_t;
 use libc::dev_t;
 use std::os::raw::{c_uint, c_void};
 
@@ -74,7 +75,7 @@ pub struct FSEventStreamContext {
 
 // https://developer.apple.com/documentation/coreservices/file_system_events
 #[link(name = "CoreServices", kind = "framework")]
-extern "C" {
+unsafe extern "C" {
     pub fn FSEventStreamCopyDescription(stream_ref: ConstFSEventStreamRef) -> CFStringRef;
     pub fn FSEventStreamCopyPathsBeingWatched(streamRef: ConstFSEventStreamRef) -> CFArrayRef;
     pub fn FSEventStreamCreate(
@@ -109,7 +110,7 @@ extern "C" {
         run_loop: CFRunLoopRef,
         run_loop_mode: CFStringRef,
     );
-    // pub fn FSEventStreamSetDispatchQueue(streamRef: FSEventStreamRef, q: DispatchQueue);
+    pub fn FSEventStreamSetDispatchQueue(stream_ref: FSEventStreamRef, q: dispatch_queue_t);
     pub fn FSEventStreamSetExclusionPaths(
         stream_ref: FSEventStreamRef,
         paths_to_exclude: CFArrayRef,

--- a/fsevent-sys/src/lib.rs
+++ b/fsevent-sys/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(target_os = "macos")]
-#![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 
 pub mod core_foundation;
 mod fsevent;


### PR DESCRIPTION
[`FSEventStreamScheduleWithRunLoop`](https://developer.apple.com/documentation/coreservices/1447824-fseventstreamschedulewithrunloop) was deprecated, and [``](https://developer.apple.com/documentation/coreservices/1444164-fseventstreamsetdispatchqueue) is the suggested equivalent. `dispatch2` was introduced for the `dispatch_queue_t` type.