### PR TITLE
Use `objc2-core-foundation` and `objc2-core-services`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "fsevent"
 version = "2.2.0"
-authors = [ "Pierre Baillet <pierre@baillet.name>" ]
+authors = ["Pierre Baillet <pierre@baillet.name>"]
 description = "Rust bindings to the fsevent-sys macOS API for file changes notifications"
 license = "MIT"
 repository = "https://github.com/octplane/fsevent-rust"
@@ -10,9 +10,17 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1"
-fsevent-sys = "5.1.0"
-# fsevent-sys = { path = "fsevent-sys" }
-core-foundation = "0.10.1"
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "CFString",
+    "CFRunLoop",
+    "CFArray",
+    "CFDate",
+] }
+objc2-core-services = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "FSEvents",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/fsevent-sys/src/lib.rs
+++ b/fsevent-sys/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "macos")]
+#![deprecated = "deprecated in favour of the `objc2-core-services` crate"]
 
 mod fsevent;
 pub use fsevent::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,18 @@ use objc2_core_foundation::{
 use objc2_core_services::FSEventStreamScheduleWithRunLoop;
 use objc2_core_services::{
     kFSEventStreamCreateFlagFileEvents, kFSEventStreamCreateFlagNoDefer,
+    kFSEventStreamEventFlagEventIdsWrapped, kFSEventStreamEventFlagHistoryDone,
+    kFSEventStreamEventFlagItemChangeOwner, kFSEventStreamEventFlagItemCloned,
+    kFSEventStreamEventFlagItemCreated, kFSEventStreamEventFlagItemFinderInfoMod,
+    kFSEventStreamEventFlagItemInodeMetaMod, kFSEventStreamEventFlagItemIsDir,
+    kFSEventStreamEventFlagItemIsFile, kFSEventStreamEventFlagItemIsHardlink,
+    kFSEventStreamEventFlagItemIsLastHardlink, kFSEventStreamEventFlagItemIsSymlink,
+    kFSEventStreamEventFlagItemModified, kFSEventStreamEventFlagItemRemoved,
+    kFSEventStreamEventFlagItemRenamed, kFSEventStreamEventFlagItemXattrMod,
+    kFSEventStreamEventFlagKernelDropped, kFSEventStreamEventFlagMount,
+    kFSEventStreamEventFlagMustScanSubDirs, kFSEventStreamEventFlagNone,
+    kFSEventStreamEventFlagOwnEvent, kFSEventStreamEventFlagRootChanged,
+    kFSEventStreamEventFlagUnmount, kFSEventStreamEventFlagUserDropped,
     kFSEventStreamEventIdSinceNow, ConstFSEventStreamRef, FSEventStreamContext,
     FSEventStreamCreate, FSEventStreamCreateFlags, FSEventStreamEventFlags, FSEventStreamEventId,
     FSEventStreamFlushSync, FSEventStreamStart, FSEventStreamStop,
@@ -56,30 +68,30 @@ pub struct Event {
 bitflags! {
   #[repr(C)]
   pub struct StreamFlags: u32 {
-    const NONE = 0x00000000;
-    const MUST_SCAN_SUBDIRS = 0x00000001;
-    const USER_DROPPED = 0x00000002;
-    const KERNEL_DROPPED = 0x00000004;
-    const IDS_WRAPPED = 0x00000008;
-    const HISTORY_DONE = 0x00000010;
-    const ROOT_CHANGED = 0x00000020;
-    const MOUNT = 0x00000040;
-    const UNMOUNT = 0x00000080;
-    const ITEM_CREATED = 0x00000100;
-    const ITEM_REMOVED = 0x00000200;
-    const INODE_META_MOD = 0x00000400;
-    const ITEM_RENAMED = 0x00000800;
-    const ITEM_MODIFIED = 0x00001000;
-    const FINDER_INFO_MOD = 0x00002000;
-    const ITEM_CHANGE_OWNER = 0x00004000;
-    const ITEM_XATTR_MOD = 0x00008000;
-    const IS_FILE = 0x00010000;
-    const IS_DIR = 0x00020000;
-    const IS_SYMLINK = 0x00040000;
-    const OWN_EVENT = 0x00080000;
-    const IS_HARDLINK = 0x00100000;
-    const IS_LAST_HARDLINK = 0x00200000;
-    const ITEM_CLONED = 0x400000;
+    const NONE = kFSEventStreamEventFlagNone;
+    const MUST_SCAN_SUBDIRS = kFSEventStreamEventFlagMustScanSubDirs;
+    const USER_DROPPED = kFSEventStreamEventFlagUserDropped;
+    const KERNEL_DROPPED = kFSEventStreamEventFlagKernelDropped;
+    const IDS_WRAPPED = kFSEventStreamEventFlagEventIdsWrapped;
+    const HISTORY_DONE = kFSEventStreamEventFlagHistoryDone;
+    const ROOT_CHANGED = kFSEventStreamEventFlagRootChanged;
+    const MOUNT = kFSEventStreamEventFlagMount;
+    const UNMOUNT = kFSEventStreamEventFlagUnmount;
+    const ITEM_CREATED = kFSEventStreamEventFlagItemCreated;
+    const ITEM_REMOVED = kFSEventStreamEventFlagItemRemoved;
+    const INODE_META_MOD = kFSEventStreamEventFlagItemInodeMetaMod;
+    const ITEM_RENAMED = kFSEventStreamEventFlagItemRenamed;
+    const ITEM_MODIFIED = kFSEventStreamEventFlagItemModified;
+    const FINDER_INFO_MOD = kFSEventStreamEventFlagItemFinderInfoMod;
+    const ITEM_CHANGE_OWNER = kFSEventStreamEventFlagItemChangeOwner;
+    const ITEM_XATTR_MOD = kFSEventStreamEventFlagItemXattrMod;
+    const IS_FILE = kFSEventStreamEventFlagItemIsFile;
+    const IS_DIR = kFSEventStreamEventFlagItemIsDir;
+    const IS_SYMLINK = kFSEventStreamEventFlagItemIsSymlink;
+    const OWN_EVENT = kFSEventStreamEventFlagOwnEvent;
+    const IS_HARDLINK = kFSEventStreamEventFlagItemIsHardlink;
+    const IS_LAST_HARDLINK = kFSEventStreamEventFlagItemIsLastHardlink;
+    const ITEM_CLONED = kFSEventStreamEventFlagItemCloned;
   }
 }
 


### PR DESCRIPTION
Use `objc2-core-foundation` as a replacement for [the soft-deprecated `core-foundation`](https://github.com/servo/core-foundation-rs/issues/729), and use `objc2-core-services`, which is an automatically generated binding to CoreServices that contains (amongst others) [the entire FSEvents API](https://developer.apple.com/documentation/coreservices/file_system_events).

Using an automatically generated binding avoids issues like #47. I've marked `fsevents-sys` as deprecated since it is completely superseded by `objc2-core-services`, it can be removed completely after the next release.

Spiritual follow-up to #44.

There shouldn't be any supply-chain issues with this, `fsevents-sys` already depends on `dispatch2`, which lives in [the same repository](https://github.com/madsmtm/objc2) as the `objc2-*` crates (all of which I maintain).